### PR TITLE
fix(chat): pause auto-scroll when user scrolls up during streaming

### DIFF
--- a/src/components/ai-message.tsx
+++ b/src/components/ai-message.tsx
@@ -1,29 +1,9 @@
 "use client";
 
 import { AIMessageText } from "@/components/message";
-import { useEffect } from "react";
 
 export function AIMessage(props: { value: string }) {
   const data = props.value;
-
-  useEffect(() => {
-    if (data) {
-      const timer = setTimeout(() => {
-        const messagesContainer = document.querySelector('[data-messages-container]');
-        if (messagesContainer) {
-          const endRef = messagesContainer.querySelector('[data-messages-end]');
-          if (endRef) {
-            endRef.scrollIntoView({
-              behavior: "smooth",
-              block: "end",
-              inline: "nearest"
-            });
-          }
-        }
-      }, 10);
-      return () => clearTimeout(timer);
-    }
-  }, [data]);
 
   if (!data) {
     return null;

--- a/src/components/use-scroll-to-bottom.ts
+++ b/src/components/use-scroll-to-bottom.ts
@@ -62,11 +62,39 @@ export function useScrollToBottom<T extends HTMLElement>(): [
         shouldAutoScrollRef.current = isNearBottom;
       };
 
+      // User-initiated upward intent (wheel up / touch drag down) pauses
+      // auto-scroll immediately, even while a programmatic scroll animation
+      // is still in flight — so the stream can't yank the view back down.
+      const handleWheel = (e: WheelEvent) => {
+        if (e.deltaY < 0) {
+          shouldAutoScrollRef.current = false;
+        }
+      };
+
+      let lastTouchY = 0;
+      const handleTouchStart = (e: TouchEvent) => {
+        lastTouchY = e.touches[0]?.clientY ?? 0;
+      };
+      const handleTouchMove = (e: TouchEvent) => {
+        const y = e.touches[0]?.clientY ?? 0;
+        // Finger moving down = scrolling content up = viewing older messages.
+        if (y > lastTouchY) {
+          shouldAutoScrollRef.current = false;
+        }
+        lastTouchY = y;
+      };
+
       container.addEventListener('scroll', handleScroll, { passive: true });
+      container.addEventListener('wheel', handleWheel, { passive: true });
+      container.addEventListener('touchstart', handleTouchStart, { passive: true });
+      container.addEventListener('touchmove', handleTouchMove, { passive: true });
 
       return () => {
         observer.disconnect();
         container.removeEventListener('scroll', handleScroll);
+        container.removeEventListener('wheel', handleWheel);
+        container.removeEventListener('touchstart', handleTouchStart);
+        container.removeEventListener('touchmove', handleTouchMove);
       };
     }
   }, [scrollToBottom]);


### PR DESCRIPTION
Remove the per-token scrollIntoView in ai-message.tsx that force-scrolled to bottom on every streamed token, overriding user intent. Streaming scroll is now handled solely by the useScrollToBottom MutationObserver, gated by a near-bottom flag. Wheel-up and touch-drag-down now pause auto-scroll immediately so the stream can't yank the view back down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-scroll behavior to respect manual upward scrolling, preventing unwanted interruptions when viewing older messages.

* **Refactor**
  * Simplified AI message component rendering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->